### PR TITLE
Error when using large value Longitude values.

### DIFF
--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -118,12 +118,12 @@ trait GeoDistanceTrait {
             ->from(DB::raw(
                 "(
                     Select *
-                    From locations
+                    From {$this->getTable()}
                     Where lat Between $minLat And $maxLat
                     And lng Between $minLng And $maxLng
                 ) As locations"
             ))
-            ->where(DB::raw("acos(sin($lat)*sin(radians(lat)) + cos($lng)*cos(radians(lat))*cos(radians(lng)-$lng)) * $distance < $lat"))
+            ->having('distance', '<=', $distance)
             ->orderby('distance', 'ASC');
     }
 


### PR DESCRIPTION
When using a large value Longitude number, no entries can be found even when using exact match lat/lng values.

Also set subquery to use Model table value instead of the hard coded 'locations' value.
