### PR TITLE
Use derived tables, which are database agnostic

### DIFF
--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -124,7 +124,7 @@ trait GeoDistanceTrait {
                     ($meanRadius * acos( cos( radians($lat) ) * cos( radians( $latColumn ) )
                     * cos( radians( $lngColumn ) - radians($lng) )
                     + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance"
-        )->from(DB::raw(' ( ' . $dubQuery->toSql() . " ) AS $this->getTable()"))
+        )->from(DB::raw(' ( ' . $subQuery->toSql() . " ) AS $this->getTable()"))
         ->mergeBindings($subQuery)
         ->having('distance', '<=', $distance)
         ->orderby('distance', 'asc');

--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -124,7 +124,7 @@ trait GeoDistanceTrait {
                     ($meanRadius * acos( cos( radians($lat) ) * cos( radians( $latColumn ) )
                     * cos( radians( $lngColumn ) - radians($lng) )
                     + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance"
-        )->from(DB::raw(' ( ' . $dubQuery->toSql() " ) AS $this->getTable()"))
+        )->from(DB::raw(' ( ' . $dubQuery->toSql() . " ) AS $this->getTable()"))
         ->mergeBindings($subQuery)
         ->having('distance' '<=' $distance)
         ->orderby('distance', 'asc');

--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -58,7 +58,7 @@ trait GeoDistanceTrait {
     *
     * Grabs the earths mean radius in a specific measurment based on the key provided, throws an exception
     * if no mean readius measurement is found
-    * 
+    *
     * @throws InvalidMeasurementException
     * @return float
     **/
@@ -114,15 +114,20 @@ trait GeoDistanceTrait {
         // Paramater bindings havent been used as it would need to be within a DB::select which would run straight away and return its result, which we dont want as it will break the query builder.
         // This method should work okay as our values have been cooerced into correct types and quoted with pdo.
 
-        return $q->select(DB::raw("*, ( $meanRadius * acos( cos( radians($lat) ) * cos( radians( $latColumn ) ) * cos( radians( $lngColumn ) - radians($lng) ) + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance"))
+        return $q->select(DB::raw("*"))
             ->from(DB::raw(
                 "(
-                    Select *
-                    From {$this->getTable()}
-                    Where $latColumn Between $minLat And $maxLat
-                    And $lngColumn Between $minLng And $maxLng
-                ) As {$this->getTable()}"
-            ))
+                    select *,
+                        ($meanRadius * acos( cos( radians($lat) ) * cos( radians( $latColumn ) )
+                        * cos( radians( $lngColumn ) - radians($lng) )
+                        + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance
+                    (
+                        select *
+                        from {$this->getTable()}
+                        where $latColumn between $minLat and $maxLat
+                        and $lngColumn between $minLng and $maxLng
+                    ) AS {$this->getTable()}
+                ) sub"))
             ->having('distance', '<=', $distance)
             ->orderby('distance', 'ASC');
     }

--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -87,7 +87,7 @@ trait GeoDistanceTrait {
     * credit - https://developers.google.com/maps/articles/phpsqlsearch_v3
     **/
 
-    public function getWithin($q, $distance, $measurement = null, $lat = null, $lng = null)
+    public function scopeWithin($q, $distance, $measurement = null, $lat = null, $lng = null)
     {
         $pdo = DB::connection()->getPdo();
 

--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -126,7 +126,7 @@ trait GeoDistanceTrait {
                     + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance"
         )->from(DB::raw(' ( ' . $dubQuery->toSql() . " ) AS $this->getTable()"))
         ->mergeBindings($subQuery)
-        ->having('distance' '<=' $distance)
+        ->having('distance', '<=', $distance)
         ->orderby('distance', 'asc');
     }
 

--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -121,7 +121,7 @@ trait GeoDistanceTrait {
                         ($meanRadius * acos( cos( radians($lat) ) * cos( radians( $latColumn ) )
                         * cos( radians( $lngColumn ) - radians($lng) )
                         + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance
-                    (
+                    from (
                         select *
                         from {$this->getTable()}
                         where $latColumn between $minLat and $maxLat

--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -114,22 +114,21 @@ trait GeoDistanceTrait {
         // Paramater bindings havent been used as it would need to be within a DB::select which would run straight away and return its result, which we dont want as it will break the query builder.
         // This method should work okay as our values have been cooerced into correct types and quoted with pdo.
 
-        return $q->select(DB::raw("*"))
-            ->from(DB::raw(
-                "(
-                    select *,
-                        ($meanRadius * acos( cos( radians($lat) ) * cos( radians( $latColumn ) )
-                        * cos( radians( $lngColumn ) - radians($lng) )
-                        + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance
-                    from (
-                        select *
-                        from {$this->getTable()}
-                        where $latColumn between $minLat and $maxLat
-                        and $lngColumn between $minLng and $maxLng
-                    ) AS {$this->getTable()}
-                ) sub"))
-            ->having('distance', '<=', $distance)
-            ->orderby('distance', 'ASC');
+        return $q->select(DB::raw("*
+            from (
+                select *,
+                    ($meanRadius * acos( cos( radians($lat) ) * cos( radians( $latColumn ) )
+                    * cos( radians( $lngColumn ) - radians($lng) )
+                    + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance
+                from (
+                    select *
+                    from {$this->getTable()}
+                    where $latColumn between $minLat and $maxLat
+                    and $lngColumn between $minLng and $maxLng
+                ) AS {$this->getTable()}
+            ) sub
+            where distance <= $1
+            order by distance asc"));
     }
 
     public function scopeOutside($q, $distance, $measurement = null, $lat = null, $lng = null)

--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -116,7 +116,7 @@ trait GeoDistanceTrait {
 
         $subQuery = DB::table($this->getTable())
             ->whereBetween($latColumn, [$minLat, $maxLat])
-            ->whereBetween($lngColumn, [$minLng, $maxLng])
+            ->whereBetween($lngColumn, [$minLng, $maxLng]);
 
         return $q->selectRaw("*
             from (

--- a/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
+++ b/src/Jackpopp/GeoDistance/GeoDistanceTrait.php
@@ -124,7 +124,7 @@ trait GeoDistanceTrait {
                     ($meanRadius * acos( cos( radians($lat) ) * cos( radians( $latColumn ) )
                     * cos( radians( $lngColumn ) - radians($lng) )
                     + sin( radians($lat) ) * sin( radians( $latColumn ) ) ) ) AS distance"
-        )->from(DB::raw(' ( ' . $dubQuery->toSql() ' ) AS {$this->getTable()}'))
+        )->from(DB::raw(' ( ' . $dubQuery->toSql() " ) AS $this->getTable()"))
         ->mergeBindings($subQuery)
         ->having('distance' '<=' $distance)
         ->orderby('distance', 'asc');


### PR DESCRIPTION
This is just for the `scopeWithin` method for now.

This does work, however Laravel doesn’t add the `{table}.deleted_at is null` constraint automatically. Maybe we’d need to do that manually.
