### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # GeoDistance
 GeoDistance allows you to search for locations within a radius using latitude and longitude values with your eloquent models.
 
-###Setup
+### Setup
 
 Add geodistance to your composer file.
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
